### PR TITLE
Modify linker script STM32F7xx

### DIFF
--- a/Linker/STM32F7xx.ld
+++ b/Linker/STM32F7xx.ld
@@ -36,8 +36,9 @@ _Min_Stack_Size = 0x400 ;	/* required amount of stack */
 /* Memories definition */
 MEMORY
 {
-  RAM    (xrw)    	: ORIGIN = 0x20000000,	LENGTH = 512K
-  FLASH  (rx)    	: ORIGIN = 0x08000000,	LENGTH = 128K
+  BL_FLAG_RAM (xrw): ORIGIN = 0x20000000,	LENGTH = 64 /* Bootloader flag in RAM */
+  RAM    (xrw)     : ORIGIN = 0x20000040,	LENGTH = 512K - 64
+  FLASH  (rx)      : ORIGIN = 0x08000000,	LENGTH = 128K
 }
 
 /* Sections */


### PR DESCRIPTION
- modify linker script STM32F7xx
- change RAM start address because of BL flag that will be placed in RAM