### PR TITLE
hash_adapter: use strlen for data length in base64 decode function

### DIFF
--- a/Bootloader/Adapters/Src/hash_adapter.c
+++ b/Bootloader/Adapters/Src/hash_adapter.c
@@ -86,7 +86,7 @@ BoardInfo_decodeBase64ManufacturerId(uint8_t* manufacturer_id) {
     bool success = false;
 
     // cppcheck-suppress misra-c2012-11.8
-    int32_t ret = Base64_decode((char*)MANUFACTURER_ID_BASE64_STR, MANUFACTURER_ID_SIZE_BASE64_STR, manufacturer_id, MANUFACTURER_ID_SIZE);
+    int32_t ret = Base64_decode((char*)MANUFACTURER_ID_BASE64_STR, strlen(MANUFACTURER_ID_BASE64_STR), manufacturer_id, MANUFACTURER_ID_SIZE);
 
     if (0 == ret) {
         success = true;


### PR DESCRIPTION
- hash_adapter - use strlen for data length in base64 decode function