### PR TITLE
makefile: separete board build folder from MCU build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,9 @@ misra:
 TARGETS	= \
 	stm32l4xx \
 	stm32h7xx \
-	stm32f7xx
+	stm32f7xx \
+	matek_H7_slim \
+	pixhawk4
 
 all:	$(TARGETS)
 
@@ -122,10 +124,13 @@ clean:
 BOARD =
 
 matek_H7_slim:
-	${MAKE} stm32h7xx BOARD=MATEK_H743_SLIM
+	${MAKE} stm32h7xx BOARD=MATEK_H743_SLIM BOARD_FILE_NAME=$@
+
+matek_H7_slim_ram:
+	${MAKE} stm32h7xx_ram BOARD=MATEK_H743_SLIM BOARD_FILE_NAME=$@
 
 pixhawk4:
-	${MAKE} stm32f7xx BOARD=PIXHAWK4
+	${MAKE} stm32f7xx BOARD=PIXHAWK4 BOARD_FILE_NAME=$@
 
 #
 # Microcontroller specific targets.
@@ -136,6 +141,9 @@ stm32l4xx: $(MAKEFILE_LIST)
 
 stm32h7xx: $(MAKEFILE_LIST)
 	${MAKE} -f Makefile.stm32h7xx LDSCRIPT=STM32H7xx.ld FLASH=INTERNAL_FLASH TARGET_FILE_NAME=$@
+	
+stm32h7xx_ram: $(MAKEFILE_LIST)
+	${MAKE} -f Makefile.stm32h7xx LDSCRIPT=STM32H7xx_RAM.ld FLASH=INTERNAL_FLASH TARGET_FILE_NAME=$@
 
 stm32h7xx_ext: $(MAKEFILE_LIST)
 	${MAKE} -f Makefile.stm32h7xx LDSCRIPT=STM32H7xx.ld FLASH=EXTERNAL_FLASH TARGET_FILE_NAME=$@

--- a/Makefile.common
+++ b/Makefile.common
@@ -1,5 +1,11 @@
 # Build path
-export BUILD_DIR = build/$(TARGET_FILE_NAME)
+ifdef BOARD
+export BUILD_DIR = build/$(BOARD_FILE_NAME)/build
+else
+export BUILD_DIR = build/$(TARGET_FILE_NAME)/build
+endif
+
+export TARGET_DIR = $(BUILD_DIR)/..
 
 C_DEFS += \
 -DGIT_BRANCH=\"$(BRANCH)\" \
@@ -17,9 +23,10 @@ endif
 
 ifdef BOARD
 CFLAGS += -D$(BOARD)
-endif
-
+TARGET := $(TARGET)_$(BOARD_FILE_NAME)
+else
 TARGET := $(TARGET)_$(TARGET_FILE_NAME)
+endif
 
 # Generate dependency information
 CFLAGS += -MMD -MP -MF"$(@:%.o=%.d)"
@@ -30,7 +37,7 @@ LIBDIR =
 LDFLAGS = $(MCU) -specs=nano.specs -TLinker/$(LDSCRIPT) $(LIBDIR) $(LIBS) -Wl,-Map=$(BUILD_DIR)/$(TARGET).map,--cref -Wl,--gc-sections
 
 # default action: build all
-all: $(BUILD_DIR)/$(TARGET).elf $(BUILD_DIR)/$(TARGET).hex $(BUILD_DIR)/$(TARGET).bin
+all: $(TARGET_DIR)/$(TARGET).elf $(TARGET_DIR)/$(TARGET).hex $(TARGET_DIR)/$(TARGET).bin
 
 
 #######################################
@@ -49,14 +56,14 @@ $(BUILD_DIR)/%.o: %.c Makefile | $(BUILD_DIR)
 $(BUILD_DIR)/%.o: %.s Makefile | $(BUILD_DIR)
 	$(AS) -c $(CFLAGS) $< -o $@
 
-$(BUILD_DIR)/$(TARGET).elf: $(OBJECTS) Makefile
+$(TARGET_DIR)/$(TARGET).elf: $(OBJECTS) Makefile
 	$(CC) $(OBJECTS) $(LDFLAGS) -o $@
 	$(SZ) $@
 
-$(BUILD_DIR)/%.hex: $(BUILD_DIR)/%.elf | $(BUILD_DIR)
+$(TARGET_DIR)/%.hex: $(TARGET_DIR)/%.elf | $(BUILD_DIR)
 	$(HEX) $< $@
 	
-$(BUILD_DIR)/%.bin: $(BUILD_DIR)/%.elf | $(BUILD_DIR)
+$(TARGET_DIR)/%.bin: $(TARGET_DIR)/%.elf | $(BUILD_DIR)
 	$(BIN) $< $@	
 	
 $(BUILD_DIR):


### PR DESCRIPTION
- Updated Makefile to separate MCU builds from board builds since they don't have the same config (different LED for blink or PIN bootloader button).
- Also elf, bin, and hex files are taken outside for easier access

Result:
![image](https://user-images.githubusercontent.com/10188706/166147279-2887ff8e-654b-46e9-b0a1-f1ce7c533ecd.png)

