### PR TITLE
Add secure communication

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -20,9 +20,13 @@ jobs:
           stm32f7xx,
           stm32f7xx_ram,
           stm32h7xx,
+          stm32h7xx secure=true,
           stm32h7xx_ram,
+          stm32h7xx_ram secure=true,
           matek_H7_slim,
+          matek_H7_slim secure=true,
           matek_H7_slim_ram,
+          matek_H7_slim_ram secure=true,
           pixhawk4,
           pixhawk4_ram
           ]

--- a/Bootloader/Adapters/Inc/security_adapter.h
+++ b/Bootloader/Adapters/Inc/security_adapter.h
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2021 - 2022 IMProject Development Team. All rights reserved.
+ *   Copyright (c) 2022 IMProject Development Team. All rights reserved.
  *   Authors: Igor Misic <igy1000mb@gmail.com>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -32,29 +32,13 @@
  *
  ****************************************************************************/
 
-#ifndef BOOTLOADER_INC_BINARYUPDATE_H_
-#define BOOTLOADER_INC_BINARYUPDATE_H_
+#ifndef BOOTLOADER_ADAPTERS_INC_SECURITY_ADAPTER_H_
+#define BOOTLOADER_ADAPTERS_INC_SECURITY_ADAPTER_H_
 
 #include <stdint.h>
 #include <stdbool.h>
-#include "signature.h"
 
-#pragma pack(push, 1)
-typedef struct bootInfo {
-    uint32_t jump_address;                  //!< Address for BL to jump
-    bool skip_bl_loop;                      //!< Flag to skip BL loop
-    detectedBinary_E previus_binary;        //!< Previous detected binary
-} bootInfo_S;
-#pragma pack(pop)
+void SecurityAdapter_init(void);
+bool SecurityAdapter_getRandomData(uint8_t* data, uint32_t size);
 
-bool BinaryUpdate_handleDetectedBinary(detectedBinary_E detected_binary);
-void BinaryUpdate_handleBootInfo(void);
-uint32_t BinaryUpdate_getJumpAddress(void);
-void BinaryUpdate_resetJumpAddress(void);
-bool BinaryUpdate_checkSkipLoopFlag(void);
-void BinaryUpdate_disableLoopFlag(void);
-bool BinaryUpdate_erase(uint32_t firmware_size);
-bool BinaryUpdate_write(uint8_t* write_buffer, const uint32_t packet_length, uint32_t* crc);
-bool BinaryUpdate_finish(void);
-
-#endif /* BOOTLOADER_INC_BINARYUPDATE_H_ */
+#endif /* BOOTLOADER_ADAPTERS_INC_SECURITY_ADAPTER_H_ */

--- a/Bootloader/Adapters/Src/flash_adapter.c
+++ b/Bootloader/Adapters/Src/flash_adapter.c
@@ -375,7 +375,8 @@ FlashAdapter_program(uint32_t address, uint8_t* buffer, uint32_t length) {
 
     if ((length_program != 0U) && (length_program < FLASH_WORD_SIZE)) {
 
-        uint8_t data[32];
+        uint8_t data[FLASH_WORD_SIZE];
+        (void*)memset((void*)data, 0xFF, FLASH_WORD_SIZE);
         (void*)memcpy((void*)data, (void*)&buffer[memory_index], length_program);
         // cppcheck-suppress misra-c2012-11.4; function expects address of data as uint32_t
         HAL_StatusTypeDef status = HAL_FLASH_Program(type_program, address + memory_index, (uint32_t)data);

--- a/Bootloader/Inc/binary_update.h
+++ b/Bootloader/Inc/binary_update.h
@@ -54,7 +54,7 @@ void BinaryUpdate_resetJumpAddress(void);
 bool BinaryUpdate_checkSkipLoopFlag(void);
 void BinaryUpdate_disableLoopFlag(void);
 bool BinaryUpdate_erase(uint32_t firmware_size);
-bool BinaryUpdate_write(uint8_t* write_buffer, const uint32_t flash_length, uint32_t* crc);
+bool BinaryUpdate_write(uint8_t* write_buffer, const uint32_t data_length, uint32_t* crc);
 bool BinaryUpdate_finish(void);
 
 #endif /* BOOTLOADER_INC_BINARYUPDATE_H_ */

--- a/Bootloader/Inc/board_info.h
+++ b/Bootloader/Inc/board_info.h
@@ -40,15 +40,10 @@
 #include <assert.h>
 #include <string.h>
 #include <main.h>
+#include "security.h"
 
 /* 32 bytes fake board id. If enabled, board and manufacturer id communication will be skipped. */
 //#define FAKE_BOARD_ID  "NOT_SECURED_MAGIC_STRING_1234567"
-
-typedef enum secureHash_ENUM {
-    BLAKE2B = 0,
-    SHA256,
-    MD5
-} secureHash_E;
 
 #define HASH_BOARD_ID_ALGORITHM             BLAKE2B //!< Selected algorithm for calculating hashed board id from UUID
 

--- a/Bootloader/STM32/Inc/stm32f7xx_hal_conf.h
+++ b/Bootloader/STM32/Inc/stm32f7xx_hal_conf.h
@@ -56,7 +56,7 @@ extern "C" {
 /* #define HAL_LPTIM_MODULE_ENABLED   */
 /* #define HAL_LTDC_MODULE_ENABLED   */
 /* #define HAL_QSPI_MODULE_ENABLED   */
-/* #define HAL_RNG_MODULE_ENABLED   */
+/* #define HAL_RNG_MODULE_ENABLED */
 /* #define HAL_RTC_MODULE_ENABLED   */
 /* #define HAL_SAI_MODULE_ENABLED   */
 /* #define HAL_SD_MODULE_ENABLED   */

--- a/Bootloader/STM32/Inc/stm32h7xx_hal_conf.h
+++ b/Bootloader/STM32/Inc/stm32h7xx_hal_conf.h
@@ -58,7 +58,7 @@ extern "C" {
 /* #define HAL_LPTIM_MODULE_ENABLED   */
 /* #define HAL_LTDC_MODULE_ENABLED   */
 #define HAL_QSPI_MODULE_ENABLED
-/* #define HAL_RNG_MODULE_ENABLED   */
+#define HAL_RNG_MODULE_ENABLED
 /* #define HAL_RTC_MODULE_ENABLED   */
 /* #define HAL_SAI_MODULE_ENABLED   */
 /* #define HAL_SD_MODULE_ENABLED   */

--- a/Bootloader/STM32/Inc/stm32l4xx_hal_conf.h
+++ b/Bootloader/STM32/Inc/stm32l4xx_hal_conf.h
@@ -79,7 +79,7 @@ extern "C" {
 #define HAL_PCD_MODULE_ENABLED
 /*#define HAL_QSPI_MODULE_ENABLED   */
 /*#define HAL_QSPI_MODULE_ENABLED   */
-/*#define HAL_RNG_MODULE_ENABLED   */
+#define HAL_RNG_MODULE_ENABLED
 #define HAL_RTC_MODULE_ENABLED
 /*#define HAL_SAI_MODULE_ENABLED   */
 /*#define HAL_SD_MODULE_ENABLED   */

--- a/Bootloader/STM32/Src/stm32h7xx_hal_msp.c
+++ b/Bootloader/STM32/Src/stm32h7xx_hal_msp.c
@@ -170,6 +170,48 @@ HAL_QSPI_MspDeInit(QSPI_HandleTypeDef* hqspi) {
 
 }
 
+/**
+* @brief RNG MSP Initialization
+* This function configures the hardware resources used in this example
+* @param hrng: RNG handle pointer
+* @retval None
+*/
+void
+HAL_RNG_MspInit(RNG_HandleTypeDef* hrng) {
+    if (hrng->Instance == RNG) {
+        /* USER CODE BEGIN RNG_MspInit 0 */
+
+        /* USER CODE END RNG_MspInit 0 */
+        /* Peripheral clock enable */
+        __HAL_RCC_RNG_CLK_ENABLE();
+        /* USER CODE BEGIN RNG_MspInit 1 */
+
+        /* USER CODE END RNG_MspInit 1 */
+    }
+
+}
+
+/**
+* @brief RNG MSP De-Initialization
+* This function freeze the hardware resources used in this example
+* @param hrng: RNG handle pointer
+* @retval None
+*/
+void
+HAL_RNG_MspDeInit(RNG_HandleTypeDef* hrng) {
+    if (hrng->Instance == RNG) {
+        /* USER CODE BEGIN RNG_MspDeInit 0 */
+
+        /* USER CODE END RNG_MspDeInit 0 */
+        /* Peripheral clock disable */
+        __HAL_RCC_RNG_CLK_DISABLE();
+        /* USER CODE BEGIN RNG_MspDeInit 1 */
+
+        /* USER CODE END RNG_MspDeInit 1 */
+    }
+
+}
+
 /* USER CODE BEGIN 1 */
 
 /* USER CODE END 1 */

--- a/Bootloader/Src/security.c
+++ b/Bootloader/Src/security.c
@@ -1,0 +1,280 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2022 IMProject Development Team. All rights reserved.
+ *   Authors: Igor Misic <igy1000mb@gmail.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name IMProject nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include "base64.h"
+#include "json.h"
+#include "monocypher.h"
+#include "security.h"
+#include "security_adapter.h"
+
+
+#define SIGNATURE_SIZE              64U //!< Size for signature binary
+#define SIGNATURE_SIZE_BASE64_STR   89U //!< Size for signature string in base64 format including null-terminator
+#define KEY_SIZE                    32U
+#define KEY_SIZE_BASE64_STR         45U //!< Size for public key string in base64 format including null-terminator
+
+static bool Security_getPresharedKey(uint8_t* preshared_key);
+static bool Security_verifySignature(const uint8_t signature[SIGNATURE_SIZE], const uint8_t public_key[KEY_SIZE]);
+static bool Security_calculateSignatureForPublicKey(const uint8_t public_key[KEY_SIZE], uint8_t signature[SIGNATURE_SIZE]);
+static bool Security_generateNewSecretKey(uint8_t secret_key[KEY_SIZE]);
+static void Security_generateNewPublicKey(const uint8_t secret_key[KEY_SIZE], uint8_t public_key[KEY_SIZE]);
+static void Security_calculateSharedKey(const uint8_t your_secret_key[KEY_SIZE], const uint8_t their_public_key[KEY_SIZE], uint8_t shared_key[KEY_SIZE]);
+
+static uint8_t s_client_public_key[KEY_SIZE];
+static uint8_t s_server_public_key[KEY_SIZE];
+static uint8_t s_client_secret_key[KEY_SIZE]; // (secret key == private key)
+static uint8_t s_shared_key[KEY_SIZE]; // For file decryption
+
+
+/* JSON String
+ * {
+*   "public_key":"mCwoSzGVUKZ9joFPj0EXZqoAh9WOI4QDv2LNqTq6LfTH6W6iEn8TCQATpDLXG9aC",
+*   "public_key_signature":"bUN3b1N6R1ZVS1o5am9GUGowRVhacW9BaDlXT0k0UUR2MkxOcVRxNkxmVEg2VzZpRW44VENRQVRwRExYRzlhQw=="
+*  }
+*/
+
+bool
+Security_setServerSecurityDataJson(char* buffer, uint16_t buffer_size) {
+    bool success = true;
+
+    if ((strlen(buffer) != SERVER_SECURITY_DATA_SIZE) && (buffer_size != SERVER_SECURITY_DATA_SIZE)) {
+        success = false;
+    }
+
+    char server_public_key_base64[KEY_SIZE_BASE64_STR];
+
+    success = Json_findByKey(buffer, buffer_size, "public_key", server_public_key_base64, KEY_SIZE_BASE64_STR);
+
+    if (success) {
+        uint32_t ret_val = Base64_decode(server_public_key_base64, strlen(server_public_key_base64), s_server_public_key, KEY_SIZE);
+
+        if (ret_val != 0U) {
+            success = false;
+        }
+    }
+
+    char server_signature_base64[SIGNATURE_SIZE_BASE64_STR];
+    success = Json_findByKey(buffer, buffer_size, "public_key_signature", server_signature_base64, SIGNATURE_SIZE_BASE64_STR);
+
+    uint8_t server_signature[SIGNATURE_SIZE];
+
+    if (success) {
+        uint32_t ret_val = Base64_decode(server_signature_base64, strlen(server_signature_base64), server_signature, SIGNATURE_SIZE);
+
+        if (ret_val != 0U) {
+            success = false;
+        }
+    }
+
+    if (success) {
+        success = Security_verifySignature(server_signature, s_server_public_key);
+        Security_calculateSharedKey(s_client_secret_key, s_server_public_key, s_shared_key);
+    }
+
+    return success;
+}
+
+bool
+Security_getClientSecurityDataJson(char* buffer, uint16_t buffer_size) {
+
+    bool success = true;
+
+    char public_key_base64[KEY_SIZE_BASE64_STR];
+    char client_signature_base64[SIGNATURE_SIZE_BASE64_STR];
+
+    success = Security_generateNewSecretKey(s_client_secret_key);
+
+    if (success) {
+
+        Security_generateNewPublicKey(s_client_secret_key, s_client_public_key);
+        int ret_val = Base64_encode(s_client_public_key, KEY_SIZE, public_key_base64, KEY_SIZE_BASE64_STR);
+
+        if (0 != ret_val) {
+            success = false;
+        }
+    }
+
+    if (success) {
+        uint8_t signature[SIGNATURE_SIZE];
+
+        success = Security_calculateSignatureForPublicKey(s_client_public_key, signature);
+        if (success) {
+            int ret_val = Base64_encode(signature, SIGNATURE_SIZE, client_signature_base64, SIGNATURE_SIZE_BASE64_STR);
+
+            if (0 != ret_val) {
+                success = false;
+            }
+        }
+
+    }
+
+    if (success) {
+        success &= Json_startString(buffer, buffer_size);
+        success &= Json_addData(buffer, buffer_size, "public_key", public_key_base64);
+        success &= Json_addData(buffer, buffer_size, "public_key_signature", client_signature_base64);
+        success &= Json_endString(buffer, buffer_size);
+    }
+
+    return success;
+}
+
+bool
+Security_isSecured(void) {
+
+#ifdef  SECURED
+    return true;
+#else
+    return false;
+#endif
+}
+
+bool
+Security_decrypt(
+    const uint8_t mac[MAC_SIZE],
+    const uint8_t nonce[NONCE_SIZE],
+    const uint8_t* cipher_data,
+    uint8_t* plain_data,
+    const uint16_t data_length) {
+
+    bool success = false;
+
+    int ret_val = crypto_unlock(plain_data, s_shared_key, nonce, mac, cipher_data, data_length);
+
+    if (ret_val == 0) {
+        success = true;
+    }
+
+    return success;
+}
+
+void
+Security_wipeKeys(void) {
+    crypto_wipe(s_shared_key, KEY_SIZE);
+    crypto_wipe(s_client_secret_key, KEY_SIZE);
+}
+
+static bool
+Security_verifySignature(const uint8_t signature[SIGNATURE_SIZE], const uint8_t public_key[KEY_SIZE]) {
+
+    bool success = false;
+
+    uint8_t preshared_key[PRESHARED_KEY_SIZE];
+    success = Security_getPresharedKey(preshared_key);
+
+    if (success) {
+
+        uint8_t calc_signature[SIGNATURE_SIZE];
+
+        switch (SIGNATURE_ALGORITHM) {
+
+            case (BLAKE2B):
+                crypto_blake2b_general((uint8_t*)calc_signature, SIGNATURE_SIZE, (const uint8_t*)preshared_key, PRESHARED_KEY_SIZE, (const uint8_t*)public_key, KEY_SIZE);
+                break;
+
+            case (SHA256):
+                //Only SMT32H75x supports HW accelerator
+                break;
+            default:
+                break;
+        }
+
+        crypto_wipe(preshared_key, PRESHARED_KEY_SIZE);
+
+        if (0 != memcmp((const void*)calc_signature, (const void*)signature, SIGNATURE_SIZE)) {
+            success = false;
+        }
+    }
+
+
+    return success;
+}
+
+static bool
+Security_calculateSignatureForPublicKey(const uint8_t public_key[KEY_SIZE], uint8_t signature[SIGNATURE_SIZE]) {
+
+    bool success = false;
+
+    uint8_t preshared_key[PRESHARED_KEY_SIZE];
+    success = Security_getPresharedKey(preshared_key);
+
+    switch (SIGNATURE_ALGORITHM) {
+
+        case (BLAKE2B):
+            crypto_blake2b_general((uint8_t*)signature, SIGNATURE_SIZE, (const uint8_t*)preshared_key, PRESHARED_KEY_SIZE, (const uint8_t*)public_key, KEY_SIZE);
+            break;
+
+        case (SHA256):
+            //Only SMT32H75x supports HW accelerator
+            break;
+        default:
+            break;
+    }
+
+    crypto_wipe(preshared_key, PRESHARED_KEY_SIZE);
+
+    return success;
+}
+
+static bool
+Security_generateNewSecretKey(uint8_t secret_key[KEY_SIZE]) {
+
+    bool success = false;
+
+    success = SecurityAdapter_getRandomData(secret_key, KEY_SIZE);
+
+    return success;
+}
+
+static void
+Security_generateNewPublicKey(const uint8_t secret_key[KEY_SIZE], uint8_t public_key[KEY_SIZE]) {
+    crypto_key_exchange_public_key(public_key, secret_key);
+}
+
+static void
+Security_calculateSharedKey(const uint8_t your_secret_key[KEY_SIZE], const uint8_t their_public_key[KEY_SIZE], uint8_t shared_key[KEY_SIZE]) {
+    crypto_key_exchange(shared_key, your_secret_key, their_public_key);
+}
+
+static bool
+Security_getPresharedKey(uint8_t* preshared_key) {
+    bool success = false;
+
+    int32_t ret = Base64_decode(PRESHARED_KEY_BASE64_STR, strlen(PRESHARED_KEY_BASE64_STR), preshared_key, PRESHARED_KEY_SIZE);
+
+    if (0 == ret) {
+        success = true;
+    }
+
+    return success;
+}

--- a/Makefile
+++ b/Makefile
@@ -26,11 +26,13 @@ export COMMON_SRCS =  \
 Bootloader/Src/main.c \
 Bootloader/Src/binary_update.c \
 Bootloader/Src/communication.c \
+Bootloader/Src/security.c \
 Bootloader/Src/signature.c \
 Bootloader/Src/board_info.c \
 Bootloader/Adapters/Src/gpio_adapter.c \
 Bootloader/Adapters/Src/flash_adapter.c \
 Bootloader/Adapters/Src/hash_adapter.c \
+Bootloader/Adapters/Src/security_adapter.c \
 Bootloader/Adapters/Src/system_adapter.c \
 Bootloader/Adapters/Src/system_clock_adapter.c \
 Bootloader/STM32/Src/usb_device.c \
@@ -99,7 +101,7 @@ format:
 .PHONY: cppcheck misra
 cppcheck:
 	$(call colorecho,'Checking code with cppcheck')
-	@cppcheck --error-exitcode=1 Bootloader
+	@cppcheck --error-exitcode=1 Bootloader -DSECURED
 
 misra:
 	$(call colorecho,'Checking MISRA C:2012 with cppcheck')

--- a/Makefile.common
+++ b/Makefile.common
@@ -35,6 +35,12 @@ else
 TARGET := $(TARGET)_$(MCU_FILE_NAME)
 endif
 
+# Check secure flag
+ifeq ($(secure), true)
+	C_DEFS +=  \
+	-DSECURED
+endif
+
 # Generate dependency information
 CFLAGS += -MMD -MP -MF"$(@:%.o=%.d)"
 

--- a/Makefile.stm32h7xx
+++ b/Makefile.stm32h7xx
@@ -19,7 +19,8 @@ Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_hal_cortex.c \
 Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_hal_exti.c \
 Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_hal_pcd.c \
 Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_hal_pcd_ex.c \
-Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_ll_usb.c
+Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_ll_usb.c \
+Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_hal_rng.c
 
 # ASM sources
 ASM_SOURCES =  \


### PR DESCRIPTION
This PR brings the capability to secure communication between [IMServer](https://imtech.hr) and IMBootloader.
The security mechanism is based on [Monocypher](https://monocypher.org). 

### How it works
The **client** (IMBootloader) and **server** (IMServer) exchange the keys to calculate the shared key. The shared key is used to encrypt the file (firmware or new bootloader) on the server side and decrypt the file on the client side. 

### Purpose
Protection from cloners.
Protection from malicious software attacks.

### Current support
Currently, it only supports the STM32H7 MCUs family. 

### Usage
Build it with:
`make stm32h7xx secure=true`
`make matek_H7_slim secure=true`
This will set a SECURED macro that will activate code for a secure bootloader. 

### Man In The Middle attack  prevention
Each time communication is started new keys are generated. This means each time different data is sent from server to client, in other words, captured data can't be used to flash it to another board with the same bootloader.

 ### Pre-shared protection
In order for a file that is arriving to be fully protected **Flash read protection** needs to be activated at IMBootlaoader.
This way the pre-shared key is protected from JTAG/SWD readout. 
If the **SECURED** flag is enabled, IMBootloader will prevent any unencrypted data to be written. 

### Other
When a secure bootloader is flashed loading unencrypted data with IMFlasher is disabled by default to prevent malicious software injection.