### PR TITLE
Use 1 byte for signature type instead of magic key

### DIFF
--- a/Bootloader/Inc/binary_update.h
+++ b/Bootloader/Inc/binary_update.h
@@ -43,11 +43,11 @@
 typedef struct bootInfo {
     uint32_t jump_address;                  //!< Address for BL to jump
     bool skip_bl_loop;                      //!< Flag to skip BL loop
-    detectedBinary_E previus_binary;        //!< Previous detected binary
+    signatureType_E previus_binary;         //!< Previous detected binary
 } bootInfo_S;
 #pragma pack(pop)
 
-bool BinaryUpdate_handleDetectedBinary(detectedBinary_E detected_binary);
+bool BinaryUpdate_handleDetectedBinary(signatureType_E detected_binary);
 void BinaryUpdate_handleBootInfo(void);
 uint32_t BinaryUpdate_getJumpAddress(void);
 void BinaryUpdate_resetJumpAddress(void);

--- a/Bootloader/Inc/signature.h
+++ b/Bootloader/Inc/signature.h
@@ -40,19 +40,22 @@
 #define SIGNATURE_SIZE 64 //!< Signature size is 64 bytes
 
 typedef struct signature {
-    uint64_t magic_key;    //!< First 8 bytes for the magic key
-    uint64_t unused[7];    //!< The rest of the 56 bytes are reserved for future use
+    uint64_t magic_key;         //!< First 8 bytes for the magic key
+    uint64_t type       : 8;    //!< Type of binary file
+    uint64_t encrypted  : 1;    //!< Indicate if file is encrypted (file only, not communication)
+    uint64_t reserved_1 : 55;   //!< The rest of bits are reserved for future use
+    uint64_t reserved_2[6];     //!< The rest of the 48 bytes are reserved for future use
 } signature_S;
 
 //! Enumeration for different signatures
-typedef enum detectedBinary_ENUM {
-    detectedBinary_FIRMWARE_FLASH,   //!< New firmware for FLASH
-    detectedBinary_FIRMWARE_RAM,     //!< Firmware for RAM
-    detectedBinary_BOOTLOADER_FLASH, //!< New bootloader for FLASH
-    detectedBinary_BOOTLOADER_RAM,   //!< Bootloader for RAM
-    detectedBinary_UNKNOWN,          //!< Not existing or unknown signature
-} detectedBinary_E;
+typedef enum signatureType_ENUM {
+    signatureType_FIRMWARE_FLASH    = 0x00, //!< New firmware for FLASH
+    signatureType_FIRMWARE_RAM      = 0x01, //!< Firmware for RAM
+    signatureType_BOOTLOADER_FLASH  = 0x02, //!< New bootloader for FLASH
+    signatureType_BOOTLOADER_RAM    = 0x03, //!< Bootloader for RAM
+    signatureType_UNKNOWN           = 0xFF, //!< Not existing or unknown signature
+} signatureType_E __attribute__ ((__packed__));
 
-detectedBinary_E Signature_verification(const signature_S* signature);
+signatureType_E Signature_verification(const signature_S* signature);
 
 #endif /* BOOTLOADER_INC_SIGNATURE_H_ */

--- a/Bootloader/Src/binary_update.c
+++ b/Bootloader/Src/binary_update.c
@@ -42,32 +42,32 @@
 __attribute__ ((section(".restart_info")))
 bootInfo_S boot_info;                       //!< Instruction on where to jump after the restart
 static uint64_t s_address;                  //!< Address from where to erase flash and write binary
-static detectedBinary_E s_detected_binary;  //!< Detected binary
+static signatureType_E s_detected_binary;  //!< Detected binary
 
 static bool BinaryUpdate_writeToFlash(uint8_t* write_buffer, const uint32_t data_length);
 
 bool
-BinaryUpdate_handleDetectedBinary(detectedBinary_E detected_binary) {
+BinaryUpdate_handleDetectedBinary(signatureType_E detected_binary) {
 
     bool success = true;
     s_detected_binary = detected_binary;
 
     switch (detected_binary) {
 
-        case detectedBinary_FIRMWARE_FLASH:
+        case signatureType_FIRMWARE_FLASH:
             s_address = FLASH_FIRMWARE_ADDRESS;
             break;
 
-        case detectedBinary_BOOTLOADER_FLASH:
+        case signatureType_BOOTLOADER_FLASH:
             s_address = FLASH_BOOTLOADER_ADDRESS;
             break;
 
-        case detectedBinary_FIRMWARE_RAM:
-        case detectedBinary_BOOTLOADER_RAM:
+        case signatureType_FIRMWARE_RAM:
+        case signatureType_BOOTLOADER_RAM:
             s_address = RAM_FIRMWARE_ADDRESS;
             break;
 
-        case detectedBinary_UNKNOWN:
+        case signatureType_UNKNOWN:
             //we support unsigned binary but handle it as firmware for flash
             success = false;
             s_address = FLASH_FIRMWARE_ADDRESS;
@@ -93,7 +93,7 @@ BinaryUpdate_handleBootInfo(void) {
         default:
             boot_info.jump_address = FLASH_FIRMWARE_ADDRESS;
             boot_info.skip_bl_loop = false;
-            boot_info.previus_binary = detectedBinary_FIRMWARE_FLASH;
+            boot_info.previus_binary = signatureType_FIRMWARE_FLASH;
             break;
     }
 }
@@ -105,7 +105,7 @@ BinaryUpdate_getJumpAddress(void) {
 
 void
 BinaryUpdate_resetJumpAddress(void) {
-    boot_info.jump_address = detectedBinary_FIRMWARE_FLASH;;
+    boot_info.jump_address = signatureType_FIRMWARE_FLASH;;
 }
 
 bool
@@ -124,21 +124,21 @@ BinaryUpdate_erase(uint32_t firmware_size) {
     bool success = true;
     switch (s_detected_binary) {
 
-        case detectedBinary_FIRMWARE_FLASH:
+        case signatureType_FIRMWARE_FLASH:
             success = FlashAdapter_erase(firmware_size, s_address);
             break;
-        case detectedBinary_BOOTLOADER_FLASH:
-            if (detectedBinary_BOOTLOADER_RAM == boot_info.previus_binary) {
+        case signatureType_BOOTLOADER_FLASH:
+            if (signatureType_BOOTLOADER_RAM == boot_info.previus_binary) {
                 //Only allowed to erase if RAM version is running
                 success = FlashAdapter_erase(firmware_size, s_address);
             }
             break;
 
-        case detectedBinary_FIRMWARE_RAM:
-        case detectedBinary_BOOTLOADER_RAM:
+        case signatureType_FIRMWARE_RAM:
+        case signatureType_BOOTLOADER_RAM:
             break;
 
-        case detectedBinary_UNKNOWN:
+        case signatureType_UNKNOWN:
             success = FlashAdapter_erase(firmware_size, s_address);
             break;
 
@@ -202,28 +202,28 @@ BinaryUpdate_finish(void) {
 
     switch (s_detected_binary) {
 
-        case detectedBinary_FIRMWARE_FLASH:
+        case signatureType_FIRMWARE_FLASH:
             boot_info.jump_address = FLASH_FIRMWARE_ADDRESS;
             boot_info.skip_bl_loop = false;
             success = FlashAdapter_finish();
             break;
 
-        case detectedBinary_FIRMWARE_RAM:
+        case signatureType_FIRMWARE_RAM:
             boot_info.jump_address = RAM_FIRMWARE_ADDRESS;
             boot_info.skip_bl_loop = false;
             break;
 
-        case detectedBinary_BOOTLOADER_FLASH:
+        case signatureType_BOOTLOADER_FLASH:
             boot_info.jump_address = FLASH_FIRMWARE_ADDRESS;
             boot_info.skip_bl_loop = false;
             break;
 
-        case detectedBinary_BOOTLOADER_RAM:
+        case signatureType_BOOTLOADER_RAM:
             boot_info.jump_address = RAM_FIRMWARE_ADDRESS;
             boot_info.skip_bl_loop = true;
             break;
 
-        case detectedBinary_UNKNOWN:
+        case signatureType_UNKNOWN:
             boot_info.jump_address = FLASH_FIRMWARE_ADDRESS;
             boot_info.skip_bl_loop = false;
             success = FlashAdapter_finish();

--- a/Bootloader/Src/communication.c
+++ b/Bootloader/Src/communication.c
@@ -243,7 +243,7 @@ Communication_handler(uint8_t* buf, uint32_t length) {
         case communicationState_CHECK_SIGNATURE: {
             signature_S signature;
             (void*)memcpy((void*)&signature, (void*)buf, SIGNATURE_SIZE);
-            detectedBinary_E binary_detected = Signature_verification(&signature);
+            signatureType_E binary_detected = Signature_verification(&signature);
             success = BinaryUpdate_handleDetectedBinary(binary_detected);
             s_update_state = communicationState_CMD_ACTION_SELECT;
 


### PR DESCRIPTION
Instead of using a full magic key to detect what type of binary is arriving (bootloader, firmware RAM/FLASH variant) use 1-byte enumeration. 