### PR TITLE
Add support for NUCLEO-H755ZI-Q board

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -23,6 +23,8 @@ jobs:
           stm32h7xx secure=true,
           stm32h7xx_ram,
           stm32h7xx_ram secure=true,
+          nucleo_h755zi,
+          nucleo_h755zi_ram,
           matek_H7_slim,
           matek_H7_slim secure=true,
           matek_H7_slim_ram,

--- a/Bootloader/Adapters/Src/system_clock_adapter.c
+++ b/Bootloader/Adapters/Src/system_clock_adapter.c
@@ -90,7 +90,7 @@ SystemClock_Config(void) {
 
     /** Supply configuration update enable
     */
-    HAL_PWREx_ConfigSupply(PWR_LDO_SUPPLY);
+    HAL_PWREx_ConfigSupply(PWR_SUPPLY);
     /** Configure the main internal regulator output voltage
     */
     __HAL_PWR_VOLTAGESCALING_CONFIG(PWR_REGULATOR_VOLTAGE_SCALE1);

--- a/Bootloader/Inc/board_info.h
+++ b/Bootloader/Inc/board_info.h
@@ -57,7 +57,9 @@
 
 #define MANUFACTURER_ID_BASE64_STR (const char*)("Qj9FKEgrTWJRZVRoV21acTR0N3cheiVDKkYpSkBOY1I=") // Size must be equal to 44 characters Base64 format (45 bytes)
 
-#ifdef MATEK_H743_SLIM
+#ifdef NUCLEO_H755ZI
+#define PRODUCT_TYPE    (const char*)("IMProject_demo-nucleo_h755zi")   // Maximum allowed size is 100 characters (101 bytes)
+#elif MATEK_H743_SLIM
 #define PRODUCT_TYPE    (const char*)("IMProject_demo-matek_H7_slim")   // Maximum allowed size is 100 characters (101 bytes)
 #elif defined(PIXHAWK4)
 #define PRODUCT_TYPE    (const char*)("IMProject_demo-pixhawk4")        // Maximum allowed size is 100 characters (101 bytes)

--- a/Bootloader/Inc/boards_config.h
+++ b/Bootloader/Inc/boards_config.h
@@ -35,15 +35,27 @@
 #ifndef BOOTLOADER_INC_BOARDS_CONFIG_H_
 #define BOOTLOADER_INC_BOARDS_CONFIG_H_
 
-/* LED configuration for board available on the market */
-
-#ifdef MATEK_H743_SLIM
+#ifdef NUCLEO_H755ZI
+#define LED1_Pin                GPIO_PIN_0
+#define LED1_Port               GPIOB
+#define LED2_Pin                GPIO_PIN_1
+#define LED2_Port               GPIOE
+#define LED_ON                  GPIO_PIN_SET
+#define LED_OFF                 GPIO_PIN_RESET
+#define BL_BUTTON_Pin           GPIO_PIN_13              //!< Button for entering in BL if pressed at boot time
+#define BL_BUTTON_Port          GPIOC
+#define BL_BUTTON_ON            GPIO_PIN_SET
+#define BL_BUTTON_OFF           GPIO_PIN_RESET
+#define BL_BUTTON_PRESS_TIME    500u                    //!< Time in [ms] needed for button to be pressed to enter in BL
+#define PWR_SUPPLY              PWR_DIRECT_SMPS_SUPPLY
+#elif MATEK_H743_SLIM
 #define LED1_Pin                GPIO_PIN_4      //!< Pin defined for green LED
 #define LED1_Port               GPIOE
 #define LED2_Pin                GPIO_PIN_3      //!< Pin defined for blue LED
 #define LED2_Port               GPIOE
 #define LED_ON                  GPIO_PIN_RESET
 #define LED_OFF                 GPIO_PIN_SET
+#define PWR_SUPPLY              PWR_LDO_SUPPLY
 #elif defined(PIXHAWK4)
 #define LED1_Pin                GPIO_PIN_6      //!< Pin defined for green LED
 #define LED1_Port               GPIOC
@@ -51,6 +63,7 @@
 #define LED2_Port               GPIOC
 #define LED_ON                  GPIO_PIN_RESET
 #define LED_OFF                 GPIO_PIN_SET
+#define PWR_SUPPLY              PWR_LDO_SUPPLY
 #else
 #define LED1_Pin                GPIO_PIN_13
 #define LED1_Port               GPIOC
@@ -63,7 +76,9 @@
 #define BL_BUTTON_ON            GPIO_PIN_SET
 #define BL_BUTTON_OFF           GPIO_PIN_RESET
 #define BL_BUTTON_PRESS_TIME    500u            //!< Time in [ms] needed for button to be pressed to enter in BL
+#define PWR_SUPPLY              PWR_LDO_SUPPLY
 #endif
 
 
 #endif /* BOOTLOADER_INC_BOARDS_CONFIG_H_ */
+

--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,7 @@ TARGETS	= \
 	stm32h7xx_ram \
 	stm32f7xx \
 	stm32f7xx_ram \
+	nucleo_h755zi \
 	matek_H7_slim \
 	matek_H7_slim_ram \
 	pixhawk4 \
@@ -136,6 +137,12 @@ clean:
 #
 BOARD =
 
+nucleo_h755zi:
+	${MAKE} stm32h7xx BOARD=NUCLEO_H755ZI BOARD_FILE_NAME=$@
+
+nucleo_h755zi_ram:
+	${MAKE} stm32h7xx_ram BOARD=NUCLEO_H755ZI BOARD_FILE_NAME=$@
+	
 matek_H7_slim:
 	${MAKE} stm32h7xx BOARD=MATEK_H743_SLIM BOARD_FILE_NAME=$@
 

--- a/Makefile.stm32h7xx
+++ b/Makefile.stm32h7xx
@@ -52,11 +52,21 @@ MCU = $(CPU) -mthumb $(FPU) $(FLOAT-ABI)
 AS_DEFS = 
 
 # C defines
-C_DEFS =  \
+C_DEFS = \
 -DUSE_HAL_DRIVER \
--DSTM32H7xx \
--DSTM32H750xx \
--DSTM32H743xx
+-DSTM32H7xx
+
+ifeq ($(BOARD), NUCLEO_H755ZI)
+  C_DEFS += \
+  -DCORE_CM7 \
+  -DSTM32H755xx
+else ifeq ($(BOARD), MATEK_H743_SLIM)
+  C_DEFS += \
+  -DSTM32H743xx
+else
+  C_DEFS += \
+  -DSTM32H750xx
+endif
 
 # AS includes
 AS_INCLUDES = 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Each MCU has its own example of [IMLedBlink](https://github.com/IMProject/IMLedB
 
 | Board                                                                      |MCU       |
 | -------------------------------------------------------------------------- |:--------:|
+| [NUCLEO-H755ZI-Q](https://www.st.com/en/evaluation-tools/nucleo-h755zi-q.html) |STM32H755ZI |
 | [Mateksys h743-slim](http://www.mateksys.com/?portfolio=h743-slim)         |STM32H7xx |
 | [Pixhawk 4](https://docs.px4.io/master/en/flight_controller/pixhawk4.html) |STM32F7xx |
 


### PR DESCRIPTION
This pull request for board [NUCLEO-H755ZI-Q](https://www.st.com/en/evaluation-tools/nucleo-h755zi-q.html) servers as tutorial on how to add new board to IMBootloader.
![image](https://github.com/user-attachments/assets/16d355d4-2c8a-4cac-b32a-edc381f0c8d7)

Example of writing an IMLedBlink application for NUCLEO-H755ZI-Q
https://github.com/IMProject/IMLedBlink/pull/5